### PR TITLE
add a `from_manifest` entrypoint for loading a destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .eggs/
 **/tmp/*.csv
 **/tmp/*.json
+**/tmp/*.manifest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 dist/
 .eggs/
 **/tmp/*.csv
+**/tmp/*.json

--- a/aws_etl_tools/redshift_ingest/__init__.py
+++ b/aws_etl_tools/redshift_ingest/__init__.py
@@ -1,10 +1,13 @@
 from .redshift_table import RedshiftTable
-from .sources import from_s3_file, from_s3_path, from_local_file, from_in_memory, from_dataframe, from_postgres_query, s3_to_redshift
+from .sources import from_s3_file, from_s3_path, \
+    from_local_file, from_in_memory, from_dataframe, from_postgres_query, from_manifest, \
+    s3_to_redshift
 
 __all__ = [
     'RedshiftTable',
     's3_to_redshift',
     'from_s3_file',
+    'from_manifest',
     'from_s3_path',
     'from_local_file',
     'from_in_memory',

--- a/aws_etl_tools/redshift_ingest/ingestors.py
+++ b/aws_etl_tools/redshift_ingest/ingestors.py
@@ -197,9 +197,11 @@ class AuditedUpsertToPostgres(AuditedUpsert):
     # 2) remove all the remote and redshifty things from the COPY command
     # 3) the ingest result tables are redshift-specific. so we'll just stub that out.
 
-    def __init__(self, file_path, destination):
+    def __init__(self, file_path, destination, **kwargs):
         local_file_path = S3File(file_path).download_to_temp()
-        super().__init__(local_file_path, destination)
+        super().__init__(local_file_path, destination, **kwargs)
+        if self.with_manifest:
+            raise ValueError("Postgres cannot handle manifests like redshift. Sorry. ")
 
     def ingest(self):
         with open(self.file_path) as local_file:

--- a/aws_etl_tools/redshift_ingest/sources.py
+++ b/aws_etl_tools/redshift_ingest/sources.py
@@ -7,10 +7,10 @@ from aws_etl_tools.s3_file import S3File
 from aws_etl_tools import config
 
 
-def s3_to_redshift(s3_file, destination):
-    file_path = s3_file.s3_path
+def s3_to_redshift(s3_file, destination, **ingestion_args):
+    s3_path = s3_file.s3_path
     ingestion_class = destination.database.ingestion_class
-    ingestor = ingestion_class(file_path, destination)
+    ingestor = ingestion_class(s3_path, destination, **ingestion_args)
     ingestor()
 
 
@@ -19,19 +19,22 @@ def from_s3_file(s3_file, destination):
 
 
 def from_s3_path(s3_path, destination):
+    '''Assumes a CSV'''
     s3_file = S3File(s3_path)
     from_s3_file(s3_file, destination)
 
 
 def from_local_file(file_path, destination):
-    s3_path = _transient_s3_path(destination)
+    '''Assumes a CSV'''
+    s3_path = _transient_s3_path(destination) + '.csv'
     s3_file = S3File.from_local_file(file_path, s3_path)
 
     from_s3_file(s3_file, destination)
 
 
 def from_in_memory(data, destination):
-    file_path = _transient_local_path(destination)
+    '''Assumes an iterable of iterables, e.g. a list of tuples'''
+    file_path = _transient_local_path(destination) + '.csv'
     with open(file_path, 'w') as f:
         writer = csv.writer(f, delimiter=',')
         for row in data:
@@ -41,7 +44,7 @@ def from_in_memory(data, destination):
 
 
 def from_dataframe(dataframe, destination, **df_kwargs):
-    file_path = _transient_local_path(destination)
+    file_path = _transient_local_path(destination) + '.csv'
     arguments = {
         'index': False,
         'header': False
@@ -53,7 +56,7 @@ def from_dataframe(dataframe, destination, **df_kwargs):
 
 
 def from_postgres_query(database, query, destination):
-    file_path = _transient_local_path(destination)
+    file_path = _transient_local_path(destination) + '.csv'
     with open(file_path, 'w') as f:
         subprocess.call([
                 'psql',
@@ -71,10 +74,6 @@ def from_postgres_query(database, query, destination):
     from_local_file(file_path, destination)
 
 
-def _destination_file_name(destination):
-    return destination.unique_identifier + '.csv'
-
-
 def _transient_local_path(destination):
     file_name = _destination_file_name(destination)
     return os.path.join(config.LOCAL_TEMP_DIRECTORY, file_name)
@@ -89,7 +88,10 @@ def _transient_s3_path(destination):
 def _s3_ingest_subpath(destination):
     database_name = destination.database.__class__.__name__.lower()
     return os.path.join(
-            database_name,
-            destination.table_schema,
-            _destination_file_name(destination)
-        )
+        database_name,
+        destination.table_schema,
+        _destination_file_name(destination)
+    )
+
+def _destination_file_name(destination):
+    return destination.unique_identifier

--- a/aws_etl_tools/redshift_ingest/sources.py
+++ b/aws_etl_tools/redshift_ingest/sources.py
@@ -15,9 +15,10 @@ def s3_to_redshift(s3_file, destination, **ingestion_args):
 
 
 def from_manifest(manifest, destination, **ingestion_args):
-    '''from a manifest dict'''
+    '''From a dict that can be jsonified and uploaded to S3. For more info on manifests,
+       see http://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html'''
     s3_path = _transient_s3_path(destination) + '.manifest'
-    s3_manifest = S3File.from_json_from_dict(manifest, s3_path)
+    s3_manifest = S3File.from_json_serializable(manifest, s3_path)
 
     s3_to_redshift(s3_manifest, destination, with_manifest=True, **ingestion_args)
 

--- a/aws_etl_tools/redshift_ingest/sources.py
+++ b/aws_etl_tools/redshift_ingest/sources.py
@@ -14,6 +14,14 @@ def s3_to_redshift(s3_file, destination, **ingestion_args):
     ingestor()
 
 
+def from_manifest(manifest, destination, **ingestion_args):
+    '''from a manifest dict'''
+    s3_path = _transient_s3_path(destination) + '.manifest'
+    s3_manifest = S3File.from_json_from_dict(manifest, s3_path)
+
+    s3_to_redshift(s3_manifest, destination, with_manifest=True, **ingestion_args)
+
+
 def from_s3_file(s3_file, destination):
     s3_to_redshift(s3_file, destination)
 

--- a/aws_etl_tools/s3_file.py
+++ b/aws_etl_tools/s3_file.py
@@ -72,7 +72,7 @@ class S3File:
         return destination_path
 
     @classmethod
-    def from_json_from_dict(cls, data, s3_path):
+    def from_json_serializable(cls, data, s3_path):
         '''Serialize a dict to json and upload it to s3.'''
         s3_path = cls._disambiguate_s3_path(s3_path)
         _, _, file_name = parse_s3_path(s3_path)
@@ -84,6 +84,9 @@ class S3File:
 
     @classmethod
     def from_in_memory_data(cls, data, s3_path):
+        '''Given some data, write it to a CSV in s3 and return an S3File abstraction.
+           `data`: a simple iterable of iterables: e.g. a list of tuples
+           `s3_path`: a full, partial, or relative s3_path'''
         s3_path = cls._disambiguate_s3_path(s3_path)
         upload_data_to_s3_path(data, s3_path)
         return cls(s3_path)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -44,9 +44,9 @@ class BasicRedshiftButActuallyPostgres(RedshiftDatabase):
 
 
 class UnloadableRedshift(BasicRedshiftButActuallyPostgres):
-    # useful for unit testing and in specific situations
-    # where local Postgres cannot be made to mock Redshift trivially
-
+    '''This database class is useful for unit testing and in specific situations
+       where a local Postgres instance cannot be made to mock Redshift because the behaviors
+       and APIs differ by too much.'''
     ingestor = Mock()
     ingestion_class = Mock()
     ingestion_class.return_value = ingestor

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -4,6 +4,7 @@ from importlib import reload
 
 import boto
 from moto import mock_s3
+from unittest.mock import Mock
 
 from aws_etl_tools import config
 from aws_etl_tools.postgres_database import PostgresDatabase
@@ -40,3 +41,12 @@ class BasicRedshiftButActuallyPostgres(RedshiftDatabase):
 
     def __init__(self):
         self.credentials = settings.REDSHIFT_TEST_CREDENTIALS
+
+
+class UnloadableRedshift(BasicRedshiftButActuallyPostgres):
+    # useful for unit testing and in specific situations
+    # where local Postgres cannot be made to mock Redshift trivially
+
+    ingestor = Mock()
+    ingestion_class = Mock()
+    ingestion_class.return_value = ingestor

--- a/tests/test_redshift_ingest_from_manifest.py
+++ b/tests/test_redshift_ingest_from_manifest.py
@@ -1,0 +1,64 @@
+import os
+import csv
+import unittest
+from unittest.mock import patch, Mock
+
+import boto
+from freezegun import freeze_time
+
+from aws_etl_tools.mock_s3_connection import MockS3Connection
+from aws_etl_tools.redshift_ingest import *
+from tests import test_helper
+
+
+class TestRedshiftIngestManifest(unittest.TestCase):
+
+    FROZEN_TIME = '2015-11-30 22:36:43.421342'
+    S3_BUCKET_NAME = test_helper.S3_TEST_BUCKET_NAME
+    SCHEMA = 'pubilc'
+    TABLENAME = 'test_channels'
+    TARGET_TABLE = '{schema}.{table}'.format(schema=SCHEMA, table=TABLENAME)
+    TARGET_DATABASE = test_helper.UnloadableRedshift()
+    EXPECTED_S3_MANIFEST_PATH = 's3://{bucket}/{db_name}/{schema}/{table}_{timestamp}.manifest'.format(
+        bucket=S3_BUCKET_NAME,
+        db_name='unloadableredshift',
+        schema=SCHEMA,
+        table=TABLENAME,
+        timestamp='2015_11_30_22_36_43'
+    )
+
+    def tearDown(self):
+        test_helper.clear_temp_directory()
+
+    def _build_working_manifest(self):
+        # upload a file with some data to s3
+        file_contents = '5,funzies\n7,sadzies\n'
+        s3_bucket_name = test_helper.S3_TEST_BUCKET_NAME
+        s3_key_name = 'namespaced/file/data.csv'
+        s3_bucket = boto.connect_s3().get_bucket(s3_bucket_name)
+        s3_bucket.new_key(s3_key_name).set_contents_from_string(file_contents)
+        full_s3_path = 's3://' + s3_bucket_name + '/' + s3_key_name
+        # create a manifest that includes that file
+        return { "entries": [{"url": full_s3_path, "mandatory": True}] }
+
+
+    @freeze_time(FROZEN_TIME)
+    @MockS3Connection(bucket=S3_BUCKET_NAME)
+    def test_manifest_to_redshift_with_mocked_ingestor_gets_called_correctly(self):
+        manifest = self._build_working_manifest()
+        destination = RedshiftTable(
+            database=self.TARGET_DATABASE,
+            target_table=self.TARGET_TABLE,
+            upsert_uniqueness_key=('id',)
+        )
+
+        from_manifest(manifest, destination)
+
+        self.TARGET_DATABASE.ingestion_class.assert_called_once_with(
+            self.EXPECTED_S3_MANIFEST_PATH,
+            destination,
+            with_manifest=True
+        )
+        self.TARGET_DATABASE.ingestor.assert_called_once_with()
+
+

--- a/tests/test_redshift_ingest_from_manifest.py
+++ b/tests/test_redshift_ingest_from_manifest.py
@@ -15,7 +15,7 @@ class TestRedshiftIngestManifest(unittest.TestCase):
 
     FROZEN_TIME = '2015-11-30 22:36:43.421342'
     S3_BUCKET_NAME = test_helper.S3_TEST_BUCKET_NAME
-    SCHEMA = 'pubilc'
+    SCHEMA = 'public'
     TABLENAME = 'test_channels'
     TARGET_TABLE = '{schema}.{table}'.format(schema=SCHEMA, table=TABLENAME)
     TARGET_DATABASE = test_helper.UnloadableRedshift()

--- a/tests/test_redshift_ingest_integration.py
+++ b/tests/test_redshift_ingest_integration.py
@@ -113,3 +113,16 @@ class TestRedshiftIngestIntegration(unittest.TestCase):
 
         self.assert_data_in_target()
         self.assert_audit_row_created()
+
+
+    @MockS3Connection()
+    def test_manifest_to_redshift_raises_value_error(self):
+        '''This cannot be integration tested because Postgres cannot trivially
+            be made to handle manifest files.'''
+        expected_exception_args = ('Postgres cannot handle manifests like redshift. Sorry. ',)
+        manifest_dict = { "entries": [{"url": 's3://this/doesnt/matter.manifest', "mandatory": True}] }
+
+        with self.assertRaises(ValueError) as exception_context_manager:
+            from_manifest(manifest_dict, self.DESTINATION)
+
+        self.assertEqual(exception_context_manager.exception.args, expected_exception_args)

--- a/tests/test_redshift_ingest_integration.py
+++ b/tests/test_redshift_ingest_integration.py
@@ -49,7 +49,7 @@ class TestRedshiftIngestIntegration(unittest.TestCase):
         self.assertEqual(actual_count_of_audit_fields, self.EXPECTED_COUNT_OF_AUDIT_FIELDS)
 
 
-    @MockS3Connection
+    @MockS3Connection()
     def test_in_memory_data_to_redshift(self):
         source_data = [[5, 'funzies'], [7, 'sadzies']]
 
@@ -59,7 +59,7 @@ class TestRedshiftIngestIntegration(unittest.TestCase):
         self.assert_audit_row_created()
 
 
-    @MockS3Connection
+    @MockS3Connection()
     def test_dataframe_to_redshift(self):
         source_dataframe = pd.DataFrame(
             [(5, 'funzies'), (7, 'sadzies')],
@@ -73,7 +73,7 @@ class TestRedshiftIngestIntegration(unittest.TestCase):
         self.assert_audit_row_created()
 
 
-    @MockS3Connection
+    @MockS3Connection()
     def test_postgres_query_to_redshift(self):
         source_db = test_helper.BasicPostgres()
         source_query = """
@@ -87,7 +87,7 @@ class TestRedshiftIngestIntegration(unittest.TestCase):
         self.assert_audit_row_created()
 
 
-    @MockS3Connection
+    @MockS3Connection()
     def test_local_file_to_redshift(self):
         file_contents = '5,funzies\n7,sadzies\n'
         file_path = os.path.join(config.LOCAL_TEMP_DIRECTORY, 'csv_data.csv')
@@ -100,7 +100,7 @@ class TestRedshiftIngestIntegration(unittest.TestCase):
         self.assert_audit_row_created()
 
 
-    @MockS3Connection
+    @MockS3Connection()
     def test_s3_path_to_redshift(self):
         file_contents = '5,funzies\n7,sadzies\n'
         s3_bucket_name = test_helper.S3_TEST_BUCKET_NAME

--- a/tests/test_s3_file.py
+++ b/tests/test_s3_file.py
@@ -1,5 +1,6 @@
 import csv
 from importlib import reload
+import json
 import os
 import unittest
 from unittest.mock import Mock
@@ -184,3 +185,22 @@ class TestS3FileFromPathObject(unittest.TestCase):
         s3_file = S3File(s3_path=self.PATH_OBJECT)
 
         self.assertEqual(s3_file.key_name, self.KEY_NAME)
+
+
+class TestS3JsonFileFromDict(unittest.TestCase):
+    S3_BUCKET_NAME = 'test-s3-bucket'
+    S3_PATH = 's3://{bucket}/namespace/configuration.json'.format(bucket=S3_BUCKET_NAME)
+    DATA = {'foo': 'bar', 'baz': 6, 'jim': False}
+
+    def tearDown(self):
+        test_helper.clear_temp_directory()
+
+
+    @MockS3Connection(bucket=S3_BUCKET_NAME)
+    def test_dictionary_becomes_json_file_in_s3(self):
+        file = S3File.from_json_from_dict(data=self.DATA, s3_path=self.S3_PATH)
+
+        temp_path = file.download_to_temp()
+        with open(temp_path) as file:
+            actual_data = json.load(file)
+        self.assertEqual(actual_data, self.DATA)

--- a/tests/test_s3_file.py
+++ b/tests/test_s3_file.py
@@ -195,10 +195,9 @@ class TestS3JsonFileFromDict(unittest.TestCase):
     def tearDown(self):
         test_helper.clear_temp_directory()
 
-
     @MockS3Connection(bucket=S3_BUCKET_NAME)
     def test_dictionary_becomes_json_file_in_s3(self):
-        file = S3File.from_json_from_dict(data=self.DATA, s3_path=self.S3_PATH)
+        file = S3File.from_json_serializable(data=self.DATA, s3_path=self.S3_PATH)
 
         temp_path = file.download_to_temp()
         with open(temp_path) as file:

--- a/tests/test_s3_to_redshift.py
+++ b/tests/test_s3_to_redshift.py
@@ -77,6 +77,23 @@ class TestS3ToRedshift(unittest.TestCase):
         self.assertEqual(current_data_in_table, self.FILE_CONTENTS)
 
 
+    @MockS3Connection(bucket=S3_BUCKET_NAME)
+    def test_additional_args_are_passed_through_to_ingestion_class(self):
+        arbitrary_s3_path = 's3://dont/care'
+        mock_s3_file = Mock(s3_path=arbitrary_s3_path)
+        arbitrary_ingestion_kwargs = { 'favorite_candy': 'snickers' }
+        unloadable_database = test_helper.UnloadableRedshift
+        unreachable_destination = RedshiftTable(unloadable_database, self.TABLE, self.UPSERT_UNIQUENESS_KEY)
+
+        s3_to_redshift(mock_s3_file, unreachable_destination, **arbitrary_ingestion_kwargs)
+
+        unloadable_database.ingestion_class.assert_called_with(
+            arbitrary_s3_path,
+            unreachable_destination,
+            **arbitrary_ingestion_kwargs
+        )
+
+
     @freeze_time(FROZEN_TIME)
     @MockS3Connection(bucket=S3_BUCKET_NAME)
     def test_upsert_audit(self):


### PR DESCRIPTION
this required a bunch of small enhancements as well.
* add `from_json_serializable` for uploading a python dict directly to a json file in s3
* add an error on attempting to upsert with_manifest to Postgres, since vanilla postgres cannot handle manifests.
* add `UnloadableRedshift`, a destination database object for convenient unit testing. see [Null Object Pattern](https://sourcemaking.com/design_patterns/null_object). 
* add ability to pass arbitrary ingestion params through s3_to_redshift directly to the ingestion_class.