### PR TITLE
Explicit s3 base path dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
-More to come, but the most important thing to know about using this library is that you need to tell it where to put things in s3. You _must_ set an environment variable for an s3_base_path before you import aws_etl_tools:
+##Overview
+This library is about helping you get your data easily and repeatably into Redshift, and it'll give you a little bit of sugar on top (e.g. convenience around managing files in s3, COPYing and LOADing directly to Redshift). `aws_etl_tools` won't help you manage the dependencies of complex workflows, and it won't help you schedule jobs on instances or in containers. It WILL help you reduce the code needed to write those jobs, and it'll give you some standardization and auditability. This is especially useful if you are using Redshift to enable querying across lots of different data schemas from lots of different places, and if you are running batch jobs using python3 to get it there.
 
+##Perspective
+This library is relatively opinionated about how to send data to Redshift, but not necessarily about where it's coming from. These opinions are what allow for the benefits of standardization. There are sources, and there are destinations.
+###Destinations: RedshiftTable
+This is is an object wrapping the context of where the data is going. Currently, there is only one that makes sense for this library, and it's `RedshiftTable`. It's (1) the target Redshift database instance, (2) the name of the table, and (3) a uniqueness identifier. Let's go through each of these.
+####database
+The Redshift instance is a database class that wraps the credentials necessary to execute commands. You can instantiate one like this:
+```python
+from aws_etl_tools.redshift_database import RedshiftDatabase
+creds = {'database_name': 'my_db'
+         'username': 'admin'
+         'password': 'PASSWORD'
+         'host': 'amazon.redshift.db.com'
+         'port': 5439}
+my_db = RedshiftDatabase(creds)
+```
+If you're going to be loading the same database a lot, we recommend subclassing this object and adding your own logic. For example, if you have an application that can run against a staging and a production environment, it might be a good idea to add the concept of an `environment` to your database abstraction.
+####target_table
+The name of the table should explicitly include the schema as well: e.g. `public.user_events`
+####upsert_uniqueness_key
+The uniqueness identifier is a tuple of the columns in your table that would be a composite primary key if Redshift allowed you to have one. The base upserting logic will use these values in your data to upsert (last-write-wins) to the target table.
+
+###Sources
+WIP
+
+##Configuration
+For a lot of the higher level functionality of this library (e.g. all the cool source -> destination stuff), you'll need to set an S3_BASE_PATH in the config, so `aws_etl_tools` can handle shuttling the data through S3 on its way to Redshift. The easiest way to do this is to set an environment variable on the instance / container or to do it yourself just before you import the library:
 ```python
 import os
-os.environ['AWS_ETL_TOOLS_S3_BASE_PATH']='s3://ye-bucket/this/isnt/optional'
+os.environ['AWS_ETL_TOOLS_S3_BASE_PATH']='s3://ye-bucket/this/is/where/we/work'
 import aws_etl_tools
 ```
-Or better yet, set the environment variable as part of the context of whatever is using this as a dependency.
+You could also set it directly on the config object like this:
+```python
+from aws_etl_tools import config
+config.S3_BASE_PATH = 's3://ye-bucket/this/is/where/we/work'
+```

--- a/aws_etl_tools/aws.py
+++ b/aws_etl_tools/aws.py
@@ -21,11 +21,15 @@ class AWS:
         build up a connection_string which is used primarily in Redshift commands like
         `COPY` from s3 and `UNLOAD` to s3.
     '''
+    PUBLICLY_LISTABLE_S3_BUCKET = 'example-publicly-accessible'
 
     def __init__(self, **kwargs):
         try:
             self._connect_with_permanent_credentials(**kwargs)
-            testable_bucket_name = config.S3_BASE_PATH.replace('s3://', '').split('/')[0]
+            if config.S3_BASE_PATH:
+                testable_bucket_name = config.S3_BASE_PATH.replace('s3://', '').split('/')[0]
+            else:
+                testable_bucket_name = self.PUBLICLY_LISTABLE_S3_BUCKET
             self.s3_connection().get_bucket(testable_bucket_name)
         except (BotoServerError, BotoClientError):
             self._connect_with_temporary_credentials()

--- a/aws_etl_tools/exceptions.py
+++ b/aws_etl_tools/exceptions.py
@@ -1,3 +1,13 @@
-class NoDataFoundError(Exception):
+class BaseAwsEtlToolsError(RuntimeError):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class NoDataFoundError(BaseAwsEtlToolsError):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class NoS3BasePathError(BaseAwsEtlToolsError):
     def __init__(self, message):
         super().__init__(message)

--- a/aws_etl_tools/guard.py
+++ b/aws_etl_tools/guard.py
@@ -1,0 +1,15 @@
+from functools import wraps
+from importlib import reload
+
+from aws_etl_tools.exceptions import NoS3BasePathError
+
+
+def requires_s3_base_path(original_function):
+    @wraps(original_function)
+    def raises_without_s3_base_path(*args, **kwargs):
+        from aws_etl_tools import config
+        if not config.S3_BASE_PATH:
+            raise NoS3BasePathError("You must set an S3_BASE_PATH to access this functionality. " \
+                                    "Check the docs around configuration of environment vaiables.")
+        return original_function(*args, **kwargs)
+    return raises_without_s3_base_path

--- a/aws_etl_tools/mock_s3_connection.py
+++ b/aws_etl_tools/mock_s3_connection.py
@@ -5,9 +5,18 @@ import boto
 from moto import mock_s3
 
 from aws_etl_tools import config
+from aws_etl_tools.guard import requires_s3_base_path
 
 
 class MockS3Connection:
+    '''This is a decorator for mocking a connection to S3 for the life of a test. You can use it
+        in two ways: with and without a bucket. If a bucket is not specified, then at import time,
+        the decorator needs to know what bucket to mock, so it will pull it out of the config. So
+        there is coupling here. The easiest way to use this is to set the bucket in the initialization
+        of the decorator. If you want to be lazy on naming a bucket, then you'll
+        have to set an S3_BASE_PATH in the config.
+    '''
+
     def __init__(self, bucket=None):
         self.bucket = bucket or s3_bucket_name_from_config()
 
@@ -23,6 +32,7 @@ class MockS3Connection:
         return with_mock_s3_connection
 
 
+@requires_s3_base_path
 def s3_bucket_name_from_config():
     s3_base_path = reload(config).S3_BASE_PATH
     bucket_name = s3_base_path.replace('s3://', '').split('/')[0]

--- a/aws_etl_tools/redshift_ingest/ingestors.py
+++ b/aws_etl_tools/redshift_ingest/ingestors.py
@@ -201,7 +201,7 @@ class AuditedUpsertToPostgres(AuditedUpsert):
         local_file_path = S3File(file_path).download_to_temp()
         super().__init__(local_file_path, destination, **kwargs)
         if self.with_manifest:
-            raise ValueError("Postgres cannot handle manifests like redshift. Sorry. ")
+            raise ValueError("Postgres cannot handle manifests like redshift. Sorry.")
 
     def ingest(self):
         with open(self.file_path) as local_file:

--- a/aws_etl_tools/redshift_ingest/sources.py
+++ b/aws_etl_tools/redshift_ingest/sources.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import subprocess
 import csv
 
+from aws_etl_tools.guard import requires_s3_base_path
 from aws_etl_tools.s3_file import S3File
 from aws_etl_tools import config
 
@@ -14,6 +15,7 @@ def s3_to_redshift(s3_file, destination, **ingestion_args):
     ingestor()
 
 
+@requires_s3_base_path
 def from_manifest(manifest, destination, **ingestion_args):
     '''From a dict that can be jsonified and uploaded to S3. For more info on manifests,
        see http://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html'''
@@ -33,6 +35,7 @@ def from_s3_path(s3_path, destination):
     from_s3_file(s3_file, destination)
 
 
+@requires_s3_base_path
 def from_local_file(file_path, destination):
     '''Assumes a CSV'''
     s3_path = _transient_s3_path(destination) + '.csv'
@@ -41,6 +44,7 @@ def from_local_file(file_path, destination):
     from_s3_file(s3_file, destination)
 
 
+@requires_s3_base_path
 def from_in_memory(data, destination):
     '''Assumes an iterable of iterables, e.g. a list of tuples'''
     file_path = _transient_local_path(destination) + '.csv'
@@ -52,6 +56,7 @@ def from_in_memory(data, destination):
     from_local_file(file_path, destination)
 
 
+@requires_s3_base_path
 def from_dataframe(dataframe, destination, **df_kwargs):
     file_path = _transient_local_path(destination) + '.csv'
     arguments = {
@@ -64,6 +69,7 @@ def from_dataframe(dataframe, destination, **df_kwargs):
     from_local_file(file_path, destination)
 
 
+@requires_s3_base_path
 def from_postgres_query(database, query, destination):
     file_path = _transient_local_path(destination) + '.csv'
     with open(file_path, 'w') as f:
@@ -88,6 +94,7 @@ def _transient_local_path(destination):
     return os.path.join(config.LOCAL_TEMP_DIRECTORY, file_name)
 
 
+@requires_s3_base_path
 def _transient_s3_path(destination):
     base_s3_path = config.S3_BASE_PATH
     s3_subpath = _s3_ingest_subpath(destination)

--- a/aws_etl_tools/s3_file.py
+++ b/aws_etl_tools/s3_file.py
@@ -7,6 +7,7 @@ from boto.s3.key import Key
 from aws_etl_tools.aws import AWS
 from aws_etl_tools import config
 from aws_etl_tools.exceptions import NoDataFoundError
+from aws_etl_tools.guard import requires_s3_base_path
 
 
 def parse_s3_path(s3_path):
@@ -117,6 +118,7 @@ class S3RelativeFilePath:
         self.sub_path = sub_path
 
     @property
+    @requires_s3_base_path
     def base_path(self):
         return config.S3_BASE_PATH
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -3,16 +3,17 @@ import boto
 from unittest.mock import Mock, PropertyMock, patch
 
 from aws_etl_tools.aws import AWS
+from aws_etl_tools import config
 from tests import test_helper
 
 
-class TestAWS(unittest.TestCase):
+class TestAWSConnectionString(unittest.TestCase):
 
     LOCAL_CONNECTION_STRING = 'aws_access_key_id=aws_mock_key;aws_secret_access_key=aws_mock_secret'
     EC2_CONNECTION_STRING = 'aws_access_key_id=aws_mock_key;aws_secret_access_key=aws_mock_secret;token=aws_mock_token'
 
     @patch.object(boto, 'connect_s3')
-    def test_aws_connection_string_from_local_authentication(self, mock_boto_connection_request):
+    def test_from_local_authentication(self, mock_boto_connection_request):
         mock_aws_connection = Mock()
         mock_aws_connection.get_bucket.return_value = None
         key_property = PropertyMock(return_value='aws_mock_key')
@@ -27,7 +28,7 @@ class TestAWS(unittest.TestCase):
 
     @patch.object(AWS, '_request_temporary_credentials')
     @patch.object(boto, 'connect_s3')
-    def test_aws_connection_string_from_ec2_iam_authentication(self, mock_boto_connection_request, mock_aws_request):
+    def test_from_ec2_iam_authentication(self, mock_boto_connection_request, mock_aws_request):
         mock_aws_connection = Mock()
         mock_aws_connection.get_bucket.side_effect = boto.exception.S3ResponseError(status=403, reason='forbidden')
         mock_boto_connection_request.return_value = mock_aws_connection
@@ -40,3 +41,19 @@ class TestAWS(unittest.TestCase):
         connection_string = AWS().connection_string()
 
         self.assertEqual(connection_string, self.EC2_CONNECTION_STRING)
+
+
+class TestInitWithoutS3BasePath(unittest.TestCase):
+    def setUp(self):
+        self.initial_s3_base_path = config.S3_BASE_PATH
+
+    def tearDown(self):
+        config.S3_BASE_PATH = self.initial_s3_base_path
+
+    @patch.object(boto, 'connect_s3')
+    def test_can_connect_without_s3_base_path(self, *_):
+        config.S3_BASE_PATH = None
+        try:
+            aws_object = AWS().s3_connection()
+        except Exception:
+            self.fail("AWS() unexpectedly raised an exception related to S3_BASE_PATH")

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -1,0 +1,115 @@
+import os
+import unittest
+
+from aws_etl_tools import config
+from aws_etl_tools.guard import requires_s3_base_path
+from aws_etl_tools.exceptions import NoS3BasePathError
+from tests import test_helper
+
+
+@requires_s3_base_path
+def function_that_uses_s3_for_something(basic_arg):
+    '''returns whatever you give it'''
+    return basic_arg
+
+
+class Arbitrary:
+    '''a class that requires config.S3_BASE_PATH for its methods'''
+    @classmethod
+    @requires_s3_base_path
+    def factory(cls):
+        '''returns an instance of this class'''
+        return cls()
+
+    @property
+    @requires_s3_base_path
+    def true_property(self):
+        '''is always true'''
+        return True
+
+    @requires_s3_base_path
+    def instance_method(self, basic_arg):
+        '''returns whatever you give it'''
+        return basic_arg
+
+
+class BaseTestingRequiresS3BasePath(unittest.TestCase):
+
+    def setUp(self):
+        self.initial_s3_base_path = config.S3_BASE_PATH
+
+    def tearDown(self):
+        config.S3_BASE_PATH = self.initial_s3_base_path
+
+    def set_s3_base_path(self, new_value):
+        config.S3_BASE_PATH = new_value
+
+
+class TestClassMethodsThatRequireS3BasePath(BaseTestingRequiresS3BasePath):
+
+    def test_factory_raises_exception_when_s3_base_path_is_not_set(self):
+        self.set_s3_base_path(None)
+
+        with self.assertRaises(NoS3BasePathError):
+            Arbitrary.factory()
+
+
+    def test_factory_works_as_expected_when_s3_base_path_is_set(self):
+        self.set_s3_base_path('any-string-will-do')
+
+        actual_return_value = Arbitrary.factory()
+
+        self.assertIsInstance(actual_return_value, Arbitrary)
+
+
+    def test_property_raises_exception_when_s3_base_path_is_not_set(self):
+        self.set_s3_base_path(None)
+
+        arbitrary_instance = Arbitrary()
+
+        with self.assertRaises(NoS3BasePathError):
+            arbitrary_instance.true_property
+
+
+    def test_property_works_as_expected_when_s3_base_path_is_set(self):
+        self.set_s3_base_path('any-string-will-do')
+
+        arbitrary_instance = Arbitrary()
+
+        self.assertEqual(arbitrary_instance.true_property, True)
+
+
+    def test_instance_method_raises_exception_when_s3_base_path_is_not_set(self):
+        self.set_s3_base_path(None)
+        testable_input = 'foobar'
+
+        with self.assertRaises(NoS3BasePathError):
+            Arbitrary().instance_method(testable_input)
+
+
+    def test_instance_method_works_as_expected_when_s3_base_path_is_set(self):
+        self.set_s3_base_path('any-string-will-do')
+        testable_input = 'foobar'
+
+        return_value = Arbitrary().instance_method(testable_input)
+
+        self.assertEqual(return_value, testable_input)
+
+
+class TestTopLevelFunctionThatRequiresS3BasePath(BaseTestingRequiresS3BasePath):
+
+    def test_raises_exception_when_s3_base_path_is_not_set(self):
+        self.set_s3_base_path(None)
+        testable_input = 'foobar'
+
+        with self.assertRaises(NoS3BasePathError):
+            function_that_uses_s3_for_something(testable_input)
+
+
+    def test_function_works_as_expected_when_s3_base_path_is_set(self):
+        self.set_s3_base_path('any-string-will-do')
+        testable_input = 'foobar'
+
+        return_value = function_that_uses_s3_for_something(testable_input)
+
+        self.assertEqual(return_value, testable_input)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -16,9 +16,10 @@ from . import settings
 S3_TEST_BUCKET_NAME = settings.S3_TEST_BUCKET_NAME
 
 
-s3_base_path = 's3://{}'.format(S3_TEST_BUCKET_NAME)
-os.environ[config.S3_BASE_PATH_ENV_VAR_KEY] = s3_base_path
-reload(config)
+def set_default_s3_base_path():
+    s3_base_path = 's3://{}'.format(S3_TEST_BUCKET_NAME)
+    os.environ[config.S3_BASE_PATH_ENV_VAR_KEY] = s3_base_path
+    reload(config)
 
 
 def clear_temp_directory():

--- a/tests/test_redshift_ingest_from_manifest.py
+++ b/tests/test_redshift_ingest_from_manifest.py
@@ -26,6 +26,7 @@ class TestRedshiftIngestManifest(unittest.TestCase):
         table=TABLENAME,
         timestamp='2015_11_30_22_36_43'
     )
+    test_helper.set_default_s3_base_path()
 
     def tearDown(self):
         test_helper.clear_temp_directory()

--- a/tests/test_redshift_ingest_integration.py
+++ b/tests/test_redshift_ingest_integration.py
@@ -31,7 +31,8 @@ class TestRedshiftIngestIntegration(unittest.TestCase):
                 value varchar(20)
             )""" % self.TARGET_TABLE
         )
-        reload(config)
+        test_helper.set_default_s3_base_path()
+
 
     def tearDown(self):
         self.TARGET_DATABASE.execute("""DROP TABLE %s""" % self.TARGET_TABLE)
@@ -119,7 +120,7 @@ class TestRedshiftIngestIntegration(unittest.TestCase):
     def test_manifest_to_redshift_raises_value_error(self):
         '''This cannot be integration tested because Postgres cannot trivially
             be made to handle manifest files.'''
-        expected_exception_args = ('Postgres cannot handle manifests like redshift. Sorry. ',)
+        expected_exception_args = ('Postgres cannot handle manifests like redshift. Sorry.',)
         manifest_dict = { "entries": [{"url": 's3://this/doesnt/matter.manifest', "mandatory": True}] }
 
         with self.assertRaises(ValueError) as exception_context_manager:


### PR DESCRIPTION
previously, all use of this library required setting S3_BASE_PATH. that was a little heavy-handed. this pr adds a decorator `@requires_s3_base_path` which will throw a `NoS3BasePathError` at runtime before calling any method that needs this configuration to be set. this PR also adds a little bit to the README. 